### PR TITLE
Add unit system selection

### DIFF
--- a/car-bmw.html
+++ b/car-bmw.html
@@ -9,6 +9,7 @@
     defaults: {
       name: {value: "", required: false},
       region: {value: 0, required: true},
+      unit: {value: "metric", required: true},
       debug: {value: false, required: true}
     },
     credentials: {
@@ -41,7 +42,14 @@
           <option value=1>USA</option>
           <option value=2>China</option>
       </select>
-  </div>
+    </div>
+    <div class="form-row">
+      <label for="node-config-input-unit"><i class="fa fa-balance-scale"></i> Mengeneinheit</label>
+      <select id="node-config-input-unit" style="width:70%">
+          <option value=metric>km &amp; l</option>
+          <option value=imperial>mi &amp; gal</option>
+      </select>
+    </div>
     <div class="form-row">
       <label>&nbsp;</label>
       <input type="checkbox" id="node-config-input-debug" style="display: inline-block; width: auto; vertical-align: top;">

--- a/car-bmw.js
+++ b/car-bmw.js
@@ -38,6 +38,7 @@ module.exports = function(RED) {
     this.name = config.name;
     this.debug = config.debug;
     this.region = config.region;
+    this.unit = config.unit;
     if (this.credentials) {
       this.username = this.credentials.username;
       this.password = this.credentials.password;
@@ -45,7 +46,7 @@ module.exports = function(RED) {
 
     // Config node state
     this.closing = false;
-    this.bmw = new Bmw(this.username, this.password, this.region);
+    this.bmw = new Bmw(this.username, this.password, this.region, this.unit);
 
     // Define functions called by nodes
     let node = this;

--- a/lib/bmw.js
+++ b/lib/bmw.js
@@ -75,16 +75,21 @@ class Bmw {
   static REGION_USA = 1;
   static REGION_CHINA = 2;
 
+  // units
+  static UNIT_METRIC = "metric";
+  static UNIT_IMPERIAL = "imperial";
+
 
   /* ---------------------------------------------------------------------------
    * Constructor
    * -------------------------------------------------------------------------*/
-  constructor(username, password, region = Bmw.REGION_REST_OF_WORLD) {
+  constructor(username, password, region = Bmw.REGION_REST_OF_WORLD, unit = Bmw.UNIT_METRIC) {
     debug(`constructor(...)`);
 
     this._username = username;
     this._password = password;
     this._region = region;
+    this._unit = unit;
     this._tokenType = undefined;
     this._token = undefined;
     this._expireTimestamp = undefined;
@@ -95,6 +100,13 @@ class Bmw {
   /* ---------------------------------------------------------------------------
    * Private Methods
    * -------------------------------------------------------------------------*/
+
+  static _getUnitFormat(unit){
+    switch (unit){
+      case Bmw.UNIT_IMPERIAL: return "d=MI;v=G";
+      default:                return "d=KM;v=L";
+    }
+  }
 
   static _getApiServerLegacy(region) {
     switch (region) {
@@ -279,7 +291,7 @@ class Bmw {
    * @param {function} callback(err, data) - Returns error or requested data.
    * @memberof Bmw
    */
-  static _request(hostname, path, token, tokenType, callback)
+  static _request(hostname, path, token, tokenType, unit, callback)
   {
     let options = {
       hostname: hostname,
@@ -288,7 +300,8 @@ class Bmw {
       method: 'GET',
       headers: {
           'x-user-agent': 'android(SP1A.210812.016.C1);bmw;2.5.2(14945)',
-          'Authorization': tokenType + " " + token
+          'Authorization': tokenType + " " + token,
+          'bmw-units-preferences': this._getUnitFormat(unit)
         }
     };
 
@@ -507,7 +520,7 @@ class Bmw {
           }
 
           // Make the request
-            Bmw._request(hostname, path, this._token, this._tokenType, (err, data) => {
+            Bmw._request(hostname, path, this._token, this._tokenType, this._unit, (err, data) => {
 
             if (err) {
               reject(err);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "node-red-contrib-car-bmw",
-  "version": "0.3.3",
+  "version": "0.4.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "node-red-contrib-car-bmw",
-      "version": "0.3.3",
+      "version": "0.4.3",
       "license": "MIT",
       "dependencies": {
         "debug": "^4.1.1",


### PR DESCRIPTION
Hello @krauskopf ,

this pull request fixes #17 as the BMW API sets now the imperial units as default instead of the metric units, as it was before. This behavior change could bee seen in the child attributes of the `status` Object.

The default if no value is defined is set to "metric". In the config node it is now possible to define the to be used unit system.

I tested it locally not sure what else needs to be done.

Best Regards,
Michael