### PR TITLE
Fix region configuration

### DIFF
--- a/car-bmw.html
+++ b/car-bmw.html
@@ -8,7 +8,7 @@
     category: "config",
     defaults: {
       name: {value: "", required: false},
-      region: {value: 0, required: true},
+      region: {value: "0", required: true},
       unit: {value: "metric", required: true},
       debug: {value: false, required: true}
     },
@@ -36,8 +36,8 @@
         <input type="password" id="node-config-input-password" />
     </div>
     <div class="form-row">
-      <label for="node-input-region"><i class="fa fa-globe"></i> Region</label>
-      <select id="node-input-region" style="width:70%">
+      <label for="node-config-input-region"><i class="fa fa-globe"></i> Region</label>
+      <select id="node-config-input-region" style="width:70%">
           <option value=0>Rest of World</option>
           <option value=1>USA</option>
           <option value=2>China</option>

--- a/lib/bmw.js
+++ b/lib/bmw.js
@@ -71,9 +71,9 @@ class Bmw {
   static SERVICE_CHARGE_NOW = 'CHARGE_NOW'
 
   // different servers for different regions
-  static REGION_REST_OF_WORLD = 0;
-  static REGION_USA = 1;
-  static REGION_CHINA = 2;
+  static REGION_REST_OF_WORLD = "0";
+  static REGION_USA = "1";
+  static REGION_CHINA = "2";
 
   // units
   static UNIT_METRIC = "metric";
@@ -88,7 +88,11 @@ class Bmw {
 
     this._username = username;
     this._password = password;
-    this._region = region;
+    if(typeof region == "number"){
+      this._region = region.toString(); //compatibility to versions <= 0.4.4
+    }else{
+      this._region = region;
+    }
     this._unit = unit;
     this._tokenType = undefined;
     this._token = undefined;


### PR DESCRIPTION
This PR fixes #8.

On the config screen the "region" selector missed the key word `config` in the ID. The select option value is a string and therefore cannot be handled like an integer.