### PR TITLE
fix: issue #22 - send post parameters in request URL in addition

### DIFF
--- a/lib/bmw.js
+++ b/lib/bmw.js
@@ -348,11 +348,11 @@ class Bmw {
    */
   static _execute(hostname, path, token, tokenType, data, callback)
   {
-    let query = querystring.stringify(data);
+    let query = (typeof data !== 'undefined') ? querystring.stringify(data) : undefined; 
     let options = {
       hostname: hostname,
       port: '443',
-      path: path + "?" + query,
+      path: path + (query ? "?" + query : ''),
       method: 'POST',
       headers: {
           'Authorization': tokenType + " " + token

--- a/lib/bmw.js
+++ b/lib/bmw.js
@@ -28,6 +28,7 @@ SOFTWARE.
 const https = require('https');
 const debug = require('debug')('bmw');
 const fetch = require('node-fetch');
+const querystring = require('querystring');
 
 
 const STATE_LOGGED_OUT = 0;
@@ -347,10 +348,11 @@ class Bmw {
    */
   static _execute(hostname, path, token, tokenType, data, callback)
   {
+    let query = querystring.stringify(data);
     let options = {
       hostname: hostname,
       port: '443',
-      path: path,
+      path: path + "?" + query,
       method: 'POST',
       headers: {
           'Authorization': tokenType + " " + token
@@ -612,7 +614,7 @@ class Bmw {
 
           // Make the request
           let path = `/eadrax-vrccs/v2/presentation/remote-commands/${vin}/${service}`;
-          let params = (typeof action !== 'undefined') ? `{"action": "${action}"}` : undefined;
+          let params = (typeof action !== 'undefined') ? {"action": action } : undefined;
 
           Bmw._execute(Bmw._getApiServerNew(this._region), path, this._token, this._tokenType, params, (err, data) => {
 


### PR DESCRIPTION
I've added the post parameters to the query string as this fixed the concrete service action to be triggered.

Before "climate-now" always triggered the climate service to be started and never to be stopped (as the concrete action was ignored and the default is to start the climate service).

That said the post parameter "action=STOP" was always ignored as it seems to be not enough to submit it via https post request body. I've added it to the request URL as query string which fixed the issue.

The query string seems to be enough and the request body seem to be not necessary. However I let it in for compatibility reason. Also, I never was able to fix the issue by only using the request body (even with application/x-www-form-urlencoded content type). Maybe specs have changed, so the action parameters need to be part of the request URL?