### PR TITLE
Add charging profile

### DIFF
--- a/car-bmw.html
+++ b/car-bmw.html
@@ -278,7 +278,8 @@
         "RCN": "Climate Start",
         "RCNSTOP": "Climate Stop",
         "RVF": "Vehicle Finder",
-        "CHARGE_NOW": "Charge Now"
+        "CHARGE_NOW": "Charge Now",
+        "CHANGE_CHARGING_MODE": "Change Charging Mode"
       };
 
       return "Action: " + text[this.action];
@@ -310,6 +311,7 @@
             <option value="RCNSTOP">Climate Stop</option>
             <option value="RVF">Vehicle Finder</option>
             <option value="CHARGE_NOW">Charge Now</option>
+            <option value="CHANGE_CHARGING_MODE">Change Charging Mode</option>
         </select>
     </div>
 </script>
@@ -323,6 +325,11 @@
       <dd> if not set in the node configuration panel, this property specifies the VIN (vehicle identification number) of the car to read the infos from.</dd>
     </dl>
 
+    <dl class="message-properties">
+      <dt class="optional">payload <span class="property-type">string</span></dt>
+      <dd> If provided, this property specifies the JSON payload body which will be sent to the car.</dd>
+    </dl>
+
   <h3>Outputs</h3>
     <dl class="message-properties">
       <dt>payload <span class="property-type">object</span></dt>
@@ -333,7 +340,8 @@
     <p>The ACTION node is used to trigger a remote service of a car. Select the desired action in the editor panel.
     You also have to specify the VIN (vehicle identification number) of your car. You can get the VIN of your car by looking in your
     documents of by using the List node.<br>
-    If no VIN is given in the node configuration panel, then the vin in <code>msg.vin</code> is used.</p>
+    If no VIN is given in the node configuration panel, then the vin in <code>msg.vin</code> is used.<br>
+    For some remote services (such as "Change Charging Mode") a payload body hast to be provided in <code>msg.payload</code> which is sent to the car in this case.</p>
 
   <h3>References</h3>
     <ul>

--- a/car-bmw.html
+++ b/car-bmw.html
@@ -208,6 +208,7 @@
             <!--<option value="efficiency">Efficiency</option>-->
             <option value="charging-statistics">Charging Statistics</option>
             <option value="charging-sessions">Charging Sessions</option>
+            <option value="chargingprofile">Charging Profile</option>
         </select>
     </div>
 </script>

--- a/car-bmw.html
+++ b/car-bmw.html
@@ -340,8 +340,10 @@
     <p>The ACTION node is used to trigger a remote service of a car. Select the desired action in the editor panel.
     You also have to specify the VIN (vehicle identification number) of your car. You can get the VIN of your car by looking in your
     documents of by using the List node.<br>
-    If no VIN is given in the node configuration panel, then the vin in <code>msg.vin</code> is used.<br>
-    For some remote services (such as "Change Charging Mode") a payload body hast to be provided in <code>msg.payload</code> which is sent to the car in this case.</p>
+    If no VIN is given in the node configuration panel, then the vin in <code>msg.vin</code> is used.<br><br>
+    For some remote services (e.g. <code>Change Charging Mode</code>) a payload body has to be provided in <code>msg.payload</code>, which is sent to the car.<br>
+    For the <code>Change Charging Mode</code> action the payload body must contain the charge and climate timer details to which the charging mode should be changed.
+    In this case the payload body must follow the object structure of the <code>chargeAndClimateTimerDetail</code> object returned by the <code>BMW Get</code> node for the data type <code>Charging Profile</code>.</p>
 
   <h3>References</h3>
     <ul>

--- a/car-bmw.js
+++ b/car-bmw.js
@@ -238,15 +238,19 @@ module.exports = function(RED) {
       this.on('input', function(msg, send, done) {
 
         let vin = node.credentials.vin;
+        let payload;
         if (msg.hasOwnProperty('vin')) {
           vin = node.credentials.vin || msg.vin;
+        }
+        if (msg.hasOwnProperty('payload')) {
+          payload = msg.payload;
         }
         if (!Bmw.isValidVin(vin)) {
           node.error('The VIN you have entered contains invalid characters. Please check.');
           return;
         }
 
-        node.configNode.bmw.executeRemoteService(vin, node.action)
+        node.configNode.bmw.executeRemoteService(vin, node.action, payload)
           .then((data) => {
 
 

--- a/lib/bmw.js
+++ b/lib/bmw.js
@@ -69,7 +69,8 @@ class Bmw {
   static SERVICE_CLIMATE_START = 'RCN';
   static SERVICE_CLIMATE_STOP = 'RCNSTOP';
   static SERVICE_VEHICLE_FINDER = 'RVF';
-  static SERVICE_CHARGE_NOW = 'CHARGE_NOW'
+  static SERVICE_CHARGE_NOW = 'CHARGE_NOW';
+  static SERVICE_CHANGE_CHARGING_MODE = 'CHANGE_CHARGING_MODE';
 
   // different servers for different regions
   static REGION_REST_OF_WORLD = "0";
@@ -348,13 +349,16 @@ class Bmw {
    * @param {string} path - The API endpoint.
    * @param {string} token - An access token.
    * @param {string} tokenType - The type of the token. Usually "Bearer".
-   * @param {object} data - The data to send in the body.
-   * @param {function} callback(err, data) - Returns error or requested data.
+   * @param {object} queryParameters - The data to send as query parameter (optional).
+   * @param {object} payloadBody - The payload to send in the request body in JSON format (optional).
+   * @param {function} callback(err, data) - Returns error or requested data (optional).
    * @memberof Bmw
    */
-  static _execute(hostname, path, token, tokenType, data, callback)
+  static _execute(hostname, path, token, tokenType, queryParameters, payloadBody, callback)
   {
-    let query = (typeof data !== 'undefined') ? querystring.stringify(data) : undefined; 
+    let query = queryParameters != null ? querystring.stringify(queryParameters) : null; 
+    // when no payload body is provided then query parameters are sent also in the payload (backward compatibility)
+    let payload = payloadBody != null ? payloadBody : (queryParameters || null); 
     let options = {
       hostname: hostname,
       port: '443',
@@ -366,8 +370,8 @@ class Bmw {
     };
 
     let postData;
-    if (data) {
-      postData = JSON.stringify(data);
+    if (payload) {
+      postData = JSON.stringify(payload);
       options.headers['Content-Type'] = 'application/json';
       options.headers['Content-Length'] = Buffer.byteLength(postData);
     }
@@ -575,13 +579,14 @@ class Bmw {
    *
    * @param {string} vin - The vehicle identification number.
    * @param {string} service - The service endpoint.
-   * @param {string} service - Some service endpoints have additional action parameter.
+   * @param {string} action - Some service endpoints have additional action parameter.
+   * @param {string} payload - Some service endpoints have an additional action payload (JSON format).
    * @returns {Promise.<Object, Error>} A promise that returns an object with the response data from the server. E.g. an eventId that can be used to query the status of execution.
    * @memberof Bmw
    */
-  async execute(vin, service, action = undefined) {
+  async execute(vin, service, action = undefined, payload = undefined) {
 
-    debug(`execute(${vin}, ${service}, ${action})`);
+    debug(`execute(${vin}, ${service}, ${action}, ${payload})`);
 
     return new Promise( (resolve, reject) => {
 
@@ -590,7 +595,7 @@ class Bmw {
         case STATE_LOGGED_OUT:
           debug(`execute() INFO not yet authenticated`);
 
-          this.requestNewToken().then(() => { return this.execute(vin, service, action); })
+          this.requestNewToken().then(() => { return this.execute(vin, service, action, payload); })
             .then((result) => { resolve(result); })
             .catch((err)   => { reject(err); });
           break;
@@ -600,7 +605,7 @@ class Bmw {
           debug(`execute() INFO authentication already in progress`);
 
           setTimeout(() => {
-            this.execute(vin, service, action)
+            this.execute(vin, service, action, payload)
               .then((result) => { resolve(result); })
               .catch((err)   => { reject(err); });
             }, 1000);
@@ -613,7 +618,7 @@ class Bmw {
           if (Date.now() > this._expireTimestamp) {
             debug(`execute() INFO token expired`);
 
-            this.requestNewToken().then(() => { return this.execute(vin, service, action); })
+            this.requestNewToken().then(() => { return this.execute(vin, service, action, payload); })
               .then((result) => { resolve(result); })
               .catch((err)   => { reject(err); });
 
@@ -621,10 +626,20 @@ class Bmw {
           }
 
           // Make the request
-          let path = `/eadrax-vrccs/v2/presentation/remote-commands/${vin}/${service}`;
-          let params = (typeof action !== 'undefined') ? {"action": action } : undefined;
+          let path, params;
+          
+          switch (service) {
+            case 'charging-profile':
+              path = `/eadrax-crccs/v1/vehicles/${vin}/${service}`;
+              break;
+            default:
+              path = `/eadrax-vrccs/v2/presentation/remote-commands/${vin}/${service}`;
+              break;
+          }
+          
+          params = action != null ? {"action": action } : null;
 
-          Bmw._execute(Bmw._getApiServerNew(this._region), path, this._token, this._tokenType, params, (err, data) => {
+          Bmw._execute(Bmw._getApiServerNew(this._region), path, this._token, this._tokenType, params, payload, (err, data) => {
 
             if (err) {
               reject(err);
@@ -727,10 +742,11 @@ class Bmw {
    *
    * @param {string} vin - The vehicle identification number.
    * @param {string} service - Which kind of remote service to execute.
+   * @param {string} payload - The payload in JSON format sent to the service (optional).
    * @returns {Promise.<Object, Error>} A promise that returns an object with an eventId, that can be used to query the status of the service.
    * @memberof Bmw
    */
-  async executeRemoteService(vin, service) {
+  async executeRemoteService(vin, service, payload) {
 
     switch (service) {
       case Bmw.SERVICE_FLASH_HEADLIGHTS:
@@ -748,7 +764,9 @@ class Bmw {
       case Bmw.SERVICE_VEHICLE_FINDER:
         return this.execute(vin, 'vehicle-finder');
       case Bmw.SERVICE_CHARGE_NOW:
-        return this.execute(vin, 'charge-now');
+        return this.execute(vin, 'charge-now'); //TODO: Not Working?
+      case Bmw.SERVICE_CHANGE_CHARGING_MODE:
+        return this.execute(vin, 'charging-profile', null, payload);
       default:
         return Promise.reject("Invalid argument");
     }

--- a/lib/bmw.js
+++ b/lib/bmw.js
@@ -293,10 +293,12 @@ class Bmw {
    * @param {string} path - The API endpoint.
    * @param {string} token - An access token.
    * @param {string} tokenType - The type of the token. Usually "Bearer".
+   * @param {string} unit - The BMW unit.
+   * @param {string} vin - The vehicle identification number.
    * @param {function} callback(err, data) - Returns error or requested data.
    * @memberof Bmw
    */
-  static _request(hostname, path, token, tokenType, unit, callback)
+  static _request(hostname, path, token, tokenType, unit, vin, callback)
   {
     let options = {
       hostname: hostname,
@@ -309,6 +311,10 @@ class Bmw {
           'bmw-units-preferences': this._getUnitFormat(unit)
         }
     };
+
+    if (vin) {
+      options.headers['bmw-vin'] = vin;
+    }
 
     const req = https.request(options, (res) => {
       let data = "";
@@ -480,13 +486,15 @@ class Bmw {
    *
    * The method will renew the token upon expiration or if none has been aquired yet.
    *
+   * @param {string} hostname - The BMW server address providing the API. (e.g. 'www.bmw-connecteddrive.com')
    * @param {string} path - The API endpoint.
+   * @param {string} vin - The vehicle identification number.
    * @returns {Promise.<Object, Error>} A promise that returns an object with the requested data.
    * @memberof Bmw
    */
-  async get(hostname, path) {
+  async get(hostname, path, vin) {
 
-    debug(`get(${hostname}, ${path})`);
+    debug(`get(${hostname}, ${path}, ${vin})`);
 
     return new Promise( (resolve, reject) => {
 
@@ -495,7 +503,7 @@ class Bmw {
         case STATE_LOGGED_OUT:
           debug(`get() INFO not yet authenticated`);
 
-          this.requestNewToken().then(() => { return this.get(hostname, path); })
+          this.requestNewToken().then(() => { return this.get(hostname, path, vin); })
             .then((result) => { resolve(result); })
             .catch((err)   => { reject(err); });
           break;
@@ -505,7 +513,7 @@ class Bmw {
           debug(`get() INFO authentication already in progress`);
 
           setTimeout(() => {
-            this.get(hostname, path)
+            this.get(hostname, path, vin)
               .then((result) => { resolve(result); })
               .catch((err)   => { reject(err); });
             }, 1000);
@@ -518,7 +526,7 @@ class Bmw {
           if (Date.now() > this._expireTimestamp) {
             debug(`get() INFO token expired`);
 
-            this.requestNewToken().then(() => { return this.get(hostname, path); })
+            this.requestNewToken().then(() => { return this.get(hostname, path, vin); })
               .then((result) => { resolve(result); })
               .catch((err)   => { reject(err); });
 
@@ -526,7 +534,7 @@ class Bmw {
           }
 
           // Make the request
-            Bmw._request(hostname, path, this._token, this._tokenType, this._unit, (err, data) => {
+            Bmw._request(hostname, path, this._token, this._tokenType, this._unit, vin, (err, data) => {
 
             if (err) {
               reject(err);
@@ -701,9 +709,10 @@ class Bmw {
       case Bmw.GET_CHARGING_SESSIONS:
         let params2 = `vin=${vin}&maxResults=40&include_date_picker=true`;
         return this.get(Bmw._getApiServerNew(this._region), '/eadrax-chs/v1/charging-sessions?' + params2);
+      case Bmw.GET_CHARGING_PROFILE:
+        return this.get(Bmw._getApiServerNew(this._region), '/eadrax-crccs/v2/vehicles?fields=charging-profile&has_charging_settings_capabilities=True', vin);
 
       // 'discontinued' services
-      case Bmw.GET_CHARGING_PROFILE:
       case Bmw.GET_STATISTICS_ALL_TRIPS:
       case Bmw.GET_STATISTICS_LAST_TRIP:
       case Bmw.GET_STATUS:


### PR DESCRIPTION
I've added "get charging profile" and "change charging mode" service.

For "get charging profile" I extended the getCarInfo node and reused the GET_CHARGING_PROFILE service. I've added the VIN to the request headers as this is required for that new service.

For "change charging mode" I extended the executeRemoteService node and added SERVICE_CHANGE_CHARGING_MODE. I've added the possibility to submit a payload body beside query parameters as this is required for that new service. For sake of simplicity the body can be submitted via msg.payload to the executeRemoteService node.

The payload body of "change charging mode" is equivalent to a subset (chargeAndClimateTimerDetail) of the response of  "get charging profile" service. Additionally you can provide "servicePack" attribute directly to the payload and "timerChange=NO_CHANGE" to the "chargingMode" object of the payload (not documented yet).

It's recommended to always call "get charging profile" service and then use the response to create the payload for "change charging mode" service with the above mentioned optional additions. For sake of simplicity and flexibility I've not added this logic, yet.

