### PR TITLE
Use vehicles v4 endpoint

### DIFF
--- a/lib/bmw.js
+++ b/lib/bmw.js
@@ -160,6 +160,33 @@ class Bmw {
 
 
   /**
+   * Helper method to parse JSON or tagged JSON ('tag1={...} tag2={...}') from V4 endpoints
+   * @param {string} data JSON or tagged JSON data
+   * @returns parsed JSON
+   */
+  static _parseTaggedJson(data) {
+    const tags = {};
+    const appendTag = (tag, index, endIndex) => {
+      if (tag) {
+        tags[tag] = JSON.parse(data.substring(index, endIndex));
+      }
+      return endIndex + 1;
+    }
+
+    let index = 0, match, tag, tagR = /([a-z]{1,32})\s*=\s*\{/gi;
+    while (match = tagR.exec(data)) {
+      const endIndex = match.index - 1;
+      const tagExpressionLength = match[0].length - 1;
+      index = appendTag(tag, index, endIndex) + tagExpressionLength;
+      tag = match[1];
+    }
+    appendTag(tag || '__json', index, data.length);
+
+    return tags['__json'] || tags;
+  }
+
+
+  /**
    * Code to request an authentication token.
    * Thanks to https://github.com/bluewalk
    * https://github.com/bluewalk/BMWConnecteDrive/blob/master/ConnectedDrive.php
@@ -291,12 +318,13 @@ class Bmw {
    *
    * @param {string} hostname - The BMW server address providing the API. (e.g. 'www.bmw-connecteddrive.com')
    * @param {string} path - The API endpoint.
+   * @param {object} headers - Extra headers (can be null).
    * @param {string} token - An access token.
    * @param {string} tokenType - The type of the token. Usually "Bearer".
    * @param {function} callback(err, data) - Returns error or requested data.
    * @memberof Bmw
    */
-  static _request(hostname, path, token, tokenType, unit, callback)
+  static _request(hostname, path, headers, token, tokenType, unit, callback)
   {
     let options = {
       hostname: hostname,
@@ -309,6 +337,10 @@ class Bmw {
           'bmw-units-preferences': this._getUnitFormat(unit)
         }
     };
+
+    if (headers) {
+      Object.assign(options.headers, headers);
+    }
 
     const req = https.request(options, (res) => {
       let data = "";
@@ -348,15 +380,15 @@ class Bmw {
    */
   static _execute(hostname, path, token, tokenType, data, callback)
   {
-    let query = (typeof data !== 'undefined') ? querystring.stringify(data) : undefined; 
+    let query = (typeof data !== 'undefined') ? querystring.stringify(data) : undefined;
     let options = {
       hostname: hostname,
       port: '443',
       path: path + (query ? "?" + query : ''),
       method: 'POST',
       headers: {
-          'Authorization': tokenType + " " + token
-        }
+        'Authorization': tokenType + " " + token
+      }
     };
 
     let postData;
@@ -480,11 +512,13 @@ class Bmw {
    *
    * The method will renew the token upon expiration or if none has been aquired yet.
    *
-   * @param {string} path - The API endpoint.
+   * @param {string} hostname - The API host.
+   * @param {string} path - The API endpoint path.
+   * @param {object} headers - Optional extra headers.
    * @returns {Promise.<Object, Error>} A promise that returns an object with the requested data.
    * @memberof Bmw
    */
-  async get(hostname, path) {
+  async get(hostname, path, headers) {
 
     debug(`get(${hostname}, ${path})`);
 
@@ -495,7 +529,7 @@ class Bmw {
         case STATE_LOGGED_OUT:
           debug(`get() INFO not yet authenticated`);
 
-          this.requestNewToken().then(() => { return this.get(hostname, path); })
+          this.requestNewToken().then(() => { return this.get(hostname, path, headers); })
             .then((result) => { resolve(result); })
             .catch((err)   => { reject(err); });
           break;
@@ -505,7 +539,7 @@ class Bmw {
           debug(`get() INFO authentication already in progress`);
 
           setTimeout(() => {
-            this.get(hostname, path)
+            this.get(hostname, path, headers)
               .then((result) => { resolve(result); })
               .catch((err)   => { reject(err); });
             }, 1000);
@@ -518,7 +552,7 @@ class Bmw {
           if (Date.now() > this._expireTimestamp) {
             debug(`get() INFO token expired`);
 
-            this.requestNewToken().then(() => { return this.get(hostname, path); })
+            this.requestNewToken().then(() => { return this.get(hostname, path, headers); })
               .then((result) => { resolve(result); })
               .catch((err)   => { reject(err); });
 
@@ -526,8 +560,7 @@ class Bmw {
           }
 
           // Make the request
-            Bmw._request(hostname, path, this._token, this._tokenType, this._unit, (err, data) => {
-
+          Bmw._request(hostname, path, headers, this._token, this._tokenType, this._unit, (err, data) => {
             if (err) {
               reject(err);
             } else {
@@ -537,7 +570,7 @@ class Bmw {
               }
 
               try {
-                let json = JSON.parse(data);
+                let json = Bmw._parseTaggedJson(data);
                 debug(`get() DONE`);
                 resolve(json);
               } catch (err) {
@@ -670,7 +703,23 @@ class Bmw {
    * @memberof Bmw
    */
   async getCarList() {
-    return this.get(Bmw._getApiServerNew(this._region), `/eadrax-vcs/v1/vehicles?apptimezone=0&appDateTime=${new Date().getTime()}&tireGuardMode=ENABLED`);
+    const host = Bmw._getApiServerNew(this._region);
+    const args = `apptimezone=0&appDateTime=${new Date().getTime()}&tireGuardMode=ENABLED`;
+
+    // get cars
+    let cars = await this.get(host, '/eadrax-vcs/v4/vehicles');
+
+    // get state for all cars
+    return Promise.all(
+      cars
+        .filter(car => Bmw.isValidVin(car['vin']))
+        .map(async car => {
+          let headers = {
+            'bmw-vin': car['vin']
+          };
+          return Object.assign(car, await this.get(host, `/eadrax-vcs/v4/vehicles/state?${args}`, headers));
+        })
+    );
   }
 
   /**


### PR DESCRIPTION
Fix for #30: Returns vehicles data using the supported V4 endpoints. 

The structure differs and as far as I could see it doesn't make much sense to map that internally. Most data is similar but not all is the same. 

This PR is a breaking change, but the only option to get the car status again (as far as I'm aware).

Example of the structural changes:


| New data path (V4)                               | Old path (V1)                                      |
| ------------------------------------------------ | -------------------------------------------------- |
| attributes.brand                                 | brand                                              |
| attributes.model                                 | model                                              |
| attributes.softwareVersionCurrent.iStep          | iStep                                              |
| attributes.softwareVersionCurrent.puStep         | puStep                                             |
| attributes.softwareVersionExFactory.iStep        | exFactoryILevel                                    |
| attributes.softwareVersionExFactory.puStep       | exFactoryPUStep                                    |
| attributes.year                                  | year                                               |
| state.chargingProfile.chargingSettings.targetSoc | status.chargingProfile.chargingSettings.targetSoc  |
| state.currentMileage                             | status.currentMileage.mileage                      |
| state.doorsState.combinedSecurityState           | `(properties.areDoorsLocked ? "SECURED" : "OPEN")` |
| state.doorsState.hood                            | properties.doorsAndWindows.trunk                   |
| state.doorsState.leftFront                       | properties.doorsAndWindows.doors.driverFront       |
| state.doorsState.leftRear                        | properties.doorsAndWindows.doors.driverRear        |
| state.doorsState.rightFront                      | properties.doorsAndWindows.doors.passengerFront    |
| state.doorsState.rightRear                       | properties.doorsAndWindows.doors.passengerRear     |
| state.doorsState.trunk                           | properties.doorsAndWindows.doors.hood              |
| state.electricChargingState.chargingLevelPercent | properties.chargingState.chargePercentage          |
| state.electricChargingState.chargingStatus       | properties.chargingState.state                     |
| state.electricChargingState.chargingTarget       | status.chargingProfile.chargingSettings.targetSoc  |
| state.electricChargingState.isChargerConnected   | properties.chargingState.isChargerConnected        |
| state.electricChargingState.range                | properties.electricRange.distance.value            |
| state.isLeftSteering                             | ?                                                  |
| state.lastUpdatedAt                              | status.lastUpdatedAt                               |
| state.location.address.formatted                 | properties.vehicleLocation.address.formatted       |
| state.location.coordinates.latitude              | properties.vehicleLocation.coordinates.latitude    |
| state.location.coordinates.longitude             | properties.vehicleLocation.coordinates.longitude   |
| state.location.heading                           | properties.vehicleLocation.heading                 |
| state.roofState.roofState                        | properties.doorsAndWindows.moonroof                |
| state.windowsState.leftFront                     | properties.doorsAndWindows.windows.driverFront     |
| state.windowsState.leftRear                      | properties.doorsAndWindows.windows.driverRear      |
| state.windowsState.rightFront                    | properties.doorsAndWindows.windows.passengerFront  |
| state.windowsState.rightRear                     | properties.doorsAndWindows.windows.passengerRear   |
| vin                                              | vin                                                |
