### PR TITLE
Fix: Add host specific unique user agent string

### DIFF
--- a/README.md
+++ b/README.md
@@ -375,7 +375,8 @@ Example of the structural changes:
 * 2023-Aug-05: 0.5.3 - Add actions to start and stop charging, thanks to @IfThenElseLoop
 * 2024-Apr-15: 0.6.0 - Updated auth scheme and use V5 vehicle list. Thanks to @jkellerer.
                      - Fixes authentication errors with new BMW API.
-* 2024-Dec-16: 0.7.0 - Fix: Add required captcha for API change. Thanks to @jkellerer.                     
+* 2024-Dec-16: 0.7.0 - Fix: Add required captcha for API change. Thanks to @jkellerer.  
+* 2025-Sep-05: 0.7.1 - Fix: Create a unique & stable `X-User-Agent` header.                   
 ```
 
 ## Credits

--- a/lib/bmw.js
+++ b/lib/bmw.js
@@ -222,21 +222,22 @@ class Bmw {
   }
 
   /**
-   * Return a host ID based on the MAC address of the first found network interface or a random multicast MAC.
+   * Return a host ID based on the MAC address of the first found network interface or a fixed ID.
    * @returns {string} MAC address without colons
    */
   static _getHostID() {
-    const interfaces = os.networkInterfaces();
-    for (const name in interfaces) {
-      const details = interfaces[name];
+    // Fallback is a fixed zero address (stable is more important than unique)
+    const zeroMac = '00:00:00:00:00:00';
+    // Finding first non-zero MAC address
+    for (const details of Object.values(os.networkInterfaces())) {
       for (const detail of details) {
-        if (detail.mac && detail.mac !== '00:00:00:00:00:00') {
-          return detail.mac.replace(/:/g, ''); // Remove colons
+        const mac = String(detail.mac || '');
+        if (mac.includes(':') && mac !== zeroMac) {
+          return mac;
         }
       }
     }
-    // Fallback, use random 48bit hex value
-    return randomBytes(6).toString('hex');
+    return zeroMac;
   }
 
   /**
@@ -244,9 +245,9 @@ class Bmw {
    * @returns {string} android version string like "AP2A.123456.789"
    */
   static _buildUAAndroidVersion() {
-    // Combine hostname and host ID into a unique string and hash it
-    const systemUuid = `${os.hostname()}-${Bmw._getHostID()}`;
-    const hash = createHash('sha256').update(systemUuid).digest('hex');
+    // Use hostname and host ID to build a unique predictable system specific hash
+    const id = `${os.hostname()}-${Bmw._getHostID()}`;
+    const hash = createHash('sha256').update(id).digest('hex');
     const digits = hash.replace(/[^0-9]/g, '');
 
     // First 6 digits → numeric part, padded to 6 digits

--- a/lib/bmw.js
+++ b/lib/bmw.js
@@ -30,6 +30,7 @@ const { URLSearchParams } = require('url');
 const https = require('https');
 const debug = require('debug')('bmw');
 const fetch = require('node-fetch');
+const os = require('os');
 
 
 const STATE_LOGGED_OUT = 0;
@@ -221,17 +222,57 @@ class Bmw {
   }
 
   /**
+   * Return a host ID based on the MAC address of the first found network interface or a random multicast MAC.
+   * @returns {string} MAC address without colons
+   */
+  static _getHostID() {
+    const interfaces = os.networkInterfaces();
+    for (const name in interfaces) {
+      const details = interfaces[name];
+      for (const detail of details) {
+        if (detail.mac && detail.mac !== '00:00:00:00:00:00') {
+          return detail.mac.replace(/:/g, ''); // Remove colons
+        }
+      }
+    }
+    // Fallback, use random 48bit hex value
+    return randomBytes(6).toString('hex');
+  }
+
+  /**
+   * Builds a host-unique version string using hostname and MAC address.
+   * @returns {string} android version string like "AP2A.123456.789"
+   */
+  static _buildUAAndroidVersion() {
+    // Combine hostname and host ID into a unique string and hash it
+    const systemUuid = `${os.hostname()}-${Bmw._getHostID()}`;
+    const hash = createHash('sha256').update(systemUuid).digest('hex');
+    const digits = hash.replace(/[^0-9]/g, '');
+
+    // First 6 digits → numeric part, padded to 6 digits
+    const numeric = digits.slice(0, 6).padEnd(6, '0');
+    // Last 3 digits → build number, padded to 3 digits
+    const buildNum = digits.slice(-3).padStart(3, '0');
+
+    return `AP2A.${numeric}.${buildNum}`;
+  }
+
+  /**
    * Returns the user agent headers for all request types.
    * @returns {Object} header object
    */
   static _userAgentHeader() {
-    const androidVersion = 'android(AP2A.240605.024)';
-    const agentVersion = '4.9.2(36892)';
-    const ua = 'Dart/3.3 (dart:io)';
-    return {
-      'User-Agent': ua,
-      'X-User-Agent': `${androidVersion};bmw;${agentVersion}`,
-    };
+    if (!Bmw._userAgentHeader._cached) {
+      const androidVersion = `android(${Bmw._buildUAAndroidVersion()})`;
+      const agentVersion = '4.9.2(36892)';
+      const ua = 'Dart/3.3 (dart:io)';
+
+      Bmw._userAgentHeader._cached = {
+        'User-Agent': ua,
+        'X-User-Agent': `${androidVersion};bmw;${agentVersion}`,
+      };
+    }
+    return Bmw._userAgentHeader._cached;
   }
 
   /**

--- a/lib/bmw.js
+++ b/lib/bmw.js
@@ -223,7 +223,7 @@ class Bmw {
 
   /**
    * Return a host ID based on the MAC address of the first found network interface or a fixed ID.
-   * @returns {string} MAC address without colons
+   * @returns {string} an ID like "01:23:45:67:89:ab"
    */
   static _getHostID() {
     // Fallback is a fixed zero address (stable is more important than unique)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-red-contrib-car-bmw",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "Node-RED nodes to connect to BMW ConnectedDrive and read infos of your car.",
   "dependencies": {
     "debug": "^4.1.1",


### PR DESCRIPTION
Fixes: #45 

This fix addresses **HTTP-401/403** errors caused by quota exceeded errors due to changes in the backend where the quota is calculated by account and `X-User-Agent`. This is a port of the solution created in `bimmer_connected`.

Based on:

* https://github.com/bimmerconnected/bimmer_connected/pull/743/files 
* https://github.com/bimmerconnected/bimmer_connected/pull/743